### PR TITLE
Solve syntax error

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8
 '''
 Written originally by @kirbylife
 This is a program to translate the articles of the english Mozilla blog to spanish.
@@ -53,7 +54,7 @@ def get_article(url):
     author = page.address
     if author:
         author = author.text.strip()
-        author_quote = f'''<p>Esta es una traducción del <a href="{url}">artículo original</a> realizado por {author}</p>'''
+        author_quote = '''<p>Esta es una traducción del <a href="{url}">artículo original</a> realizado por {author}</p>'''
         article_translated = author_quote + "\n" + article_translated
     return article_translated
 


### PR DESCRIPTION
Prevent errors:

-   File "app.py", line 30
SyntaxError: Non-ASCII character '\xc3' in file app.py on line 30, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

-   File "app.py", line 57
    author_quote = f'''<p>Esta es una traducción del <a href="{url}">artículo original</a> realizado por {author}</p>'''
                                                                                                                         ^
SyntaxError: invalid syntax
